### PR TITLE
Updating lib paths

### DIFF
--- a/lib-dyn/deps.ts
+++ b/lib-dyn/deps.ts
@@ -4,10 +4,10 @@ export const tarn = dex_tarn;
 import dex_inherits from "https://dev.jspm.io/inherits@2.0";
 export const inherits = dex_inherits;
 
-import dex_events from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/events.js";
+import dex_events from "node:events";
 export const events = dex_events;
 
-import dex_util from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/util.js";
+import dex_util from "node:util";
 export const util = dex_util;
 
 import dex_lodash from "https://dev.jspm.io/lodash@4";
@@ -16,23 +16,23 @@ export const _ = dex_lodash;
 import dex_debug from "https://dev.jspm.io/debug@4.1.1";
 export const debug = dex_debug;
 
-import * as dex_colors from "https://deno.land/std/fmt/colors.ts";
+import * as dex_colors from "https://deno.land/std@0.224.0/fmt/colors.ts";
 export const colors = dex_colors;
 
-import * as dex_uuid from "https://deno.land/std/uuid/mod.ts";
+import * as dex_uuid from "https://deno.land/std@0.224.0/uuid/mod.ts";
 export const uuid = dex_uuid;
 
-import * as dex_path from "https://deno.land/std/path/mod.ts";
+import * as dex_path from "https://deno.land/std@0.224.0/path/mod.ts";
 export const path = dex_path;
 
-import dex_assert from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/assert.js";
+import dex_assert from "node:assert";
 export const assert = dex_assert;
 
-import dex_url from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/url.js";
+import dex_url from "node:url";
 export const url = dex_url;
 
 import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.2.0";
 export const pgconn = dex_pgconn;
 
-import dex_stream from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/stream.js";
+import dex_stream from "node:stream";
 export const stream = dex_stream;


### PR DESCRIPTION
This PR fixes this issue: 

<img width="838" height="213" alt="image" src="https://github.com/user-attachments/assets/ee14b719-89e2-4c03-a973-2fb16f7b07fa" />

```
> deno task start
Task start deno run -A --watch=static/,routes/ dev.ts
Watcher Process started.
The manifest has been generated for 13 routes and 8 islands.
error: Uncaught (in promise) TypeError: Module not found "https://deno.land/std@0.224.0/node/events.ts".
    at https://raw.githubusercontent.com/Zhomart/dex/930253915093e1e08d48ec0409b4aee800d8bd0c/lib-dyn/deps.ts:7:24
  const manifest = (await import(toFileUrl(join(dir, "fresh.gen.ts")).href))
                    ^
    at async dev (https://deno.land/x/fresh@1.7.3/src/dev/dev_command.ts:38:21)
    at async file:///C:/Users/tubal/Projects/kayozen/dev.ts:8:1
Watcher Process failed. Restarting on file change...
```

